### PR TITLE
README.md: changed verticalGridStep example to integer 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class SimpleChart extends Component {
             <View style={styles.container}>
                 <RNChart style={styles.chart}
                     chartData={chartData}
-                    verticalGridStep="5"
+                    verticalGridStep={5}
                     xLabels={xLabels}>
                 </RNChart>
             </View>


### PR DESCRIPTION
Changed `verticalGridStep` example to integer 5 instead of a string to prevent this error:

```
JSON value '5' of type NSString cannot be converted to NSNumber
```
