### PR TITLE
Update for React Native ^0.15.0

### DIFF
--- a/Chart.ios.js
+++ b/Chart.ios.js
@@ -1,65 +1,60 @@
 'use strict';
 
 var React = require('react-native');
-var PropTypes = require('ReactPropTypes');
-var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var createReactNativeComponentClass = require('createReactNativeComponentClass');
-var StyleSheet = require('StyleSheet');
-var NativeMethodsMixin = require('NativeMethodsMixin');
-var flattenStyle = require('flattenStyle');
+var {
+    PropTypes,
+    StyleSheet,
+    requireNativeComponent
+} = React;
 var merge = require('merge');
-var { View } = React;
 
-var RNChartView = createReactNativeComponentClass({
-    validAttributes: merge(ReactNativeViewAttributes.UIView, {
-        chartData:true,
-        verticalGridStep:true,
-        animationDuration:true,
+/** A native reference to the chart view */
+var CHART_REF = 'chart';
 
-        showGrid:true,
-        gridColor:true,
-        gridLineWidth:true,
+/** The native chart view */
+var RNChartView = requireNativeComponent('RNChartView', RNChart);
 
-        showAxis:true,
-        showXAxisLabels:true,
-        showYAxisLabels:true,
-        xLabels:true,
-        xAxisTitle:true,
-        yAxisTitle:true,
-        axisTitleColor:true,
-        axisTitleFontSize:true,
-        axisColor:true,
-        axisLineWidth:true,
-
-        labelFontSize:true,
-        labelTextColor:true,
-
-        chartTitle:true,
-        chartTitleColor:true,
-        chartFontSize:true
-    }),
-    uiViewClassName: 'RNChartView'
+/** A base styles object that the user can override by passing in their own styles */
+var styles = StyleSheet.create({
+    base: {}
 });
 
+/** Our bridge component */
 var RNChart = React.createClass({
-    mixins: [NativeMethodsMixin],
-
-    viewConfig: {
-        uiViewClassName: 'UIView',
-        validAttributes: ReactNativeViewAttributes.UIView
+    propTypes: {
+        // TODO: define what these objects look like
+        chartData: PropTypes.array.isRequired,
+        xLabels: PropTypes.array.isRequired,
+        animationDuration: PropTypes.number,
+        showGrid: PropTypes.bool,
+        verticalGridStep: PropTypes.number,
+        // TODO: allow strings and use processColor to convert
+        gridColor: PropTypes.number,
+        gridLineWidth: PropTypes.number,
+        showAxis: PropTypes.bool,
+        showXAxisLabels: PropTypes.bool,
+        showYAxisLabels: PropTypes.bool,
+        axisLineWidth: PropTypes.number,
+        labelFontSize: PropTypes.number,
+        // TODO: allow strings and use processColor to convert
+        labelTextColor: PropTypes.number
     },
 
+    /** Pass the props to the native component */
+    setNativeProps(props) {
+        this.refs[CHART_REF].setNativeProps(props);
+    },
+
+    /** Render the native component with the correct props */
     render() {
+        var style = [styles.base, this.props.style];
         var nativeProps = merge(this.props, {
-            style: this.props.style,
+            style,
             chartData: this.props.chartData
         });
 
-        return <RNChartView {... nativeProps} />
+        return <RNChartView ref={CHART_REF} {... nativeProps} />;
     }
-});
-
-var styles = StyleSheet.create({
 });
 
 module.exports = RNChart;

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "react-native-chart",
   "version": "0.0.4",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/onefold/react-native-chart.git"
+    "type": "git",
+    "url": "https://github.com/onefold/react-native-chart.git"
   },
   "main": "Chart.ios.js",
   "author": "Hyun Cho <hyun@onefold.io> (http://onefold.io)",
   "peerDependencies": {
-    "react-native": "^0.4.0"
+    "react-native": "^0.15.0"
   },
   "keywords": [
     "react-native",
@@ -18,5 +18,8 @@
     "native",
     "chart",
     "graph"
-  ]
+  ],
+  "dependencies": {
+    "merge": "^1.2.0"
+  }
 }


### PR DESCRIPTION
Fixes #33 

• Add merge as dependency
• Use `requireNativeComponent` and `setNativeProps` instead of `createNativeComponentClass` and `viewConfig`
• Require `StyleSheet` from `react-native` instead of it's own thing
• No longer need `NativeMethodsMixin`
• No longer need `flattenStyle`
• Define `propTypes` in react class
• Added comments
