### PR TITLE
Changed usage example in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class SimpleChart extends Component {
 					data={data}
 					verticalGridStep={5}
 					type="line"
-					showDataPoint=={true}
+					showDataPoint={true}
 				 />
 			</View>
 		);

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ class SimpleChart extends Component {
 					data={data}
 					verticalGridStep={5}
 					type="line"
+					showDataPoint=={true}
 				 />
 			</View>
 		);


### PR DESCRIPTION
I saw several people open issues about this and changed the readme example by adding
`showDataPoint={true}`

to the first example. Without this the chart will appear to be empty if using the documentation example exactly.

This is my first PR so please let me know if I need to do anything differently.
