### PR TITLE
Fix horizontal grid

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -27,11 +27,11 @@ export default class Grid extends Component {
 		const data = this.props.data || [[]];
 		const unique = uniqueValuesInDataSet(data[0]);
 		const horizontalSteps = (unique.length < this.props.verticalGridStep) ? unique.length : this.props.verticalGridStep;
-		let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round(data.length / this.props.horizontalGridStep) : 1;
+		let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round(data[0].length / this.props.horizontalGridStep) : 1;
 		if (stepsBetweenVerticalLines < 1) stepsBetweenVerticalLines = 1;
 
 		for (let i = horizontalSteps; i > 0; i--) horizontalRange.push(i);
-		for (let i = data.length - 1; i > 0; i -= stepsBetweenVerticalLines) verticalRange.push(i);
+		for (let i = data[0].length - 1; i > 0; i -= stepsBetweenVerticalLines) verticalRange.push(i);
 
 		const containerStyle = { width: this.props.width, height: this.props.height, position: 'absolute', left: 0 };
 
@@ -49,7 +49,7 @@ export default class Grid extends Component {
 
 		const verticalGridStyle = {
 			height: this.props.height + 1,
-			width: (this.props.width / (data.length - 1)) * stepsBetweenVerticalLines,
+			width: (this.props.width / (data[0].length - 1)) * stepsBetweenVerticalLines,
 			borderRightColor: this.props.gridColor,
 			borderRightWidth: intendedLineWidth,
 		};

--- a/src/xAxis.js
+++ b/src/xAxis.js
@@ -55,7 +55,7 @@ export default class XAxis extends Component {
 			{(() => {
 				if (!this.props.showXAxisLabels) return null;
 				return data.map((d, i) => {
-					let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round((data.length) / this.props.horizontalGridStep + 1) : 1;
+					let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round((data[0].length) / this.props.horizontalGridStep + 1) : 1;
 					if (stepsBetweenVerticalLines < 1) stepsBetweenVerticalLines = 1;
 					if (i % stepsBetweenVerticalLines !== 0) return null;
 					const item = transform(d[0]);


### PR DESCRIPTION
This fixes the horizontal grid partly (it seems that this went missing while changing data to a multidimensional array).

Merging the pull request https://github.com/tomauty/react-native-chart/commit/597394b99b37d6d8038d988deee0498b16916b3d left a real mess! For example The changes in src/xAxis.js include only changes to the default value, nothing else has been adapted to the new data layout! This needs more fixes..

Btw: I think the horizontal grid does not really work well this way as it is bound to the sample steps, see #62.
