### PR TITLE
Fix horizontal grid and axis

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -24,8 +24,8 @@ export default class Grid extends Component {
 		if (!this.props.showGrid) return null;
 		const horizontalRange = [];
 		const verticalRange = [];
-		const data = this.props.data || [[]];
-		const unique = uniqueValuesInDataSet(data[0]);
+		const data = (this.props.data || [[]])[0];
+		const unique = uniqueValuesInDataSet(data);
 		const horizontalSteps = (unique.length < this.props.verticalGridStep) ? unique.length : this.props.verticalGridStep;
 		let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round(data.length / this.props.horizontalGridStep) : 1;
 		if (stepsBetweenVerticalLines < 1) stepsBetweenVerticalLines = 1;

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { uniqueValuesInDataSet } from './util';
+import { uniqueValuesInDataSets } from './util';
 
 export default class Grid extends Component {
 	static propTypes = {
@@ -24,14 +24,14 @@ export default class Grid extends Component {
 		if (!this.props.showGrid) return null;
 		const horizontalRange = [];
 		const verticalRange = [];
-		const data = (this.props.data || [[]])[0];
-		const unique = uniqueValuesInDataSet(data);
-		const horizontalSteps = (unique.length < this.props.verticalGridStep) ? unique.length : this.props.verticalGridStep;
-		let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round(data.length / this.props.horizontalGridStep) : 1;
+		const xData = uniqueValuesInDataSets(this.props.data || [[]], 0);
+		const yData = uniqueValuesInDataSets(this.props.data || [[]], 1);
+		const horizontalSteps = (yData.length < this.props.verticalGridStep) ? yData.length : this.props.verticalGridStep;
+		let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round(xData.length / this.props.horizontalGridStep) : 1;
 		if (stepsBetweenVerticalLines < 1) stepsBetweenVerticalLines = 1;
 
 		for (let i = horizontalSteps; i > 0; i--) horizontalRange.push(i);
-		for (let i = data.length - 1; i > 0; i -= stepsBetweenVerticalLines) verticalRange.push(i);
+		for (let i = xData.length - 1; i > 0; i -= stepsBetweenVerticalLines) verticalRange.push(i);
 
 		const containerStyle = { width: this.props.width, height: this.props.height, position: 'absolute', left: 0 };
 
@@ -49,7 +49,7 @@ export default class Grid extends Component {
 
 		const verticalGridStyle = {
 			height: this.props.height + 1,
-			width: (this.props.width / (data.length - 1)) * stepsBetweenVerticalLines,
+			width: (this.props.width / (xData.length - 1)) * stepsBetweenVerticalLines,
 			borderRightColor: this.props.gridColor,
 			borderRightWidth: intendedLineWidth,
 		};

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -6,6 +6,7 @@ import * as C from './constants';
 import Circle from './Circle';
 const AnimatedShape = Animated.createAnimatedComponent(Shape);
 import Grid from './Grid';
+import { uniqueValuesInDataSets } from './util';
 
 const makeDataPoint = (x : number, y : number, data : any, index : number) => {
 
@@ -69,7 +70,7 @@ export default class LineChart extends Component<void, any, any> {
 
 		const divisor = calculateDivisor(minBound, maxBound);
 		const scale = (containerHeight + 1) / divisor;
-		const horizontalStep = containerWidth / data[0].length;
+		const horizontalStep = containerWidth / uniqueValuesInDataSets(data, 0).length;
 
 		const dataPoints = [];
 		const path = [];

--- a/src/util.js
+++ b/src/util.js
@@ -7,3 +7,18 @@ export function uniqueValuesInDataSet(data : Pair[]) : Pair[] {
 		return result;
 	}, []);
 }
+
+export function uniqueValuesInDataSets(data : [Pair[]], index : number) : Pair[] {
+	let values = [];
+	data.forEach(Graph => {
+		Graph.forEach(XYPair => {
+			if (values.indexOf(XYPair[index]) === -1) {
+				values.push(XYPair[index])
+			}
+		})
+	});
+	values.sort(function(a, b) {
+	  return a - b;
+	});
+	return values
+}

--- a/src/xAxis.js
+++ b/src/xAxis.js
@@ -2,6 +2,7 @@
 'use strict';
 import React, { Component, PropTypes } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { uniqueValuesInDataSets } from './util';
 
 const styles = StyleSheet.create({
 	xAxisContainer: {
@@ -36,7 +37,7 @@ export default class XAxis extends Component {
 	};
 
 	render() {
-		const data = (this.props.data || [[]])[0];
+		const data = uniqueValuesInDataSets(this.props.data || [[]], 0);
 		let transform = (d) => d;
 		if (this.props.xAxisTransform && typeof this.props.xAxisTransform === 'function') {
 			transform = this.props.xAxisTransform;
@@ -58,7 +59,7 @@ export default class XAxis extends Component {
 					let stepsBetweenVerticalLines = this.props.horizontalGridStep ? Math.round((data.length) / this.props.horizontalGridStep + 1) : 1;
 					if (stepsBetweenVerticalLines < 1) stepsBetweenVerticalLines = 1;
 					if (i % stepsBetweenVerticalLines !== 0) return null;
-					const item = transform(d[0]);
+					const item = transform(d);
 					if (typeof item !== 'number' && !item) return null;
 					return (
 						<Text

--- a/src/xAxis.js
+++ b/src/xAxis.js
@@ -36,7 +36,7 @@ export default class XAxis extends Component {
 	};
 
 	render() {
-		const data = this.props.data || [[]];
+		const data = (this.props.data || [[]])[0];
 		let transform = (d) => d;
 		if (this.props.xAxisTransform && typeof this.props.xAxisTransform === 'function') {
 			transform = this.props.xAxisTransform;

--- a/src/yAxis.js
+++ b/src/yAxis.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, { Component, PropTypes } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { uniqueValuesInDataSet } from './util';
+import { uniqueValuesInDataSets } from './util';
 
 const styles = StyleSheet.create({
 	yAxisContainer: {
@@ -93,9 +93,8 @@ export default class YAxis extends Component<void, any, any> {
 
 	render() {
 		const range = [];
-		const data = this.props.data || [[]];
-		const unique = uniqueValuesInDataSet(data[0]);
-		const steps = (unique.length < this.props.verticalGridStep) ? unique.length : this.props.verticalGridStep;
+		const data = uniqueValuesInDataSets(this.props.data || [[]], 1);
+		const steps = (data.length < this.props.verticalGridStep) ? data.length : this.props.verticalGridStep;
 		for (let i = steps; i >= 0; i--) range.push(i);
 		return (
 			<View


### PR DESCRIPTION
This is a quick and dirty bugfix for #137. It assumes that the first data series defines the range of the x values.

The better solution would be to iterate over the set of unique x-values from all data series.
